### PR TITLE
Reduce the number of memcached checks

### DIFF
--- a/page_view_log/middleware.py
+++ b/page_view_log/middleware.py
@@ -37,7 +37,7 @@ class PageViewLogMiddleware(MiddlewareMixin, object):
             # Wait for the other process to complete.
             stime = time.time()
             while cache.get(request.pvl_uid):
-                time.sleep(.01)
+                time.sleep(0.2)
                 if time.time() > (stime + 60):
                     # it's been 60 seconds. time to give up on waiting and process as normal.
                     return None


### PR DESCRIPTION
From the original commit:

Reduce the frequency our our checks to memcached; to lighten up on our network activity. #SAO-805

Within this logic; the duplicate request waits (up to 60 seconds) for the original request to finish. And while it waits, it currently generates a considerable number of memcached 'gets' to check whether the original request is done yet.